### PR TITLE
Fix requirements.txt dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ websockets==12.0
 sqlalchemy==2.0.23
 alembic==1.12.1
 asyncpg==0.29.0
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.7
 
 # Redis
 redis==5.0.1
@@ -17,14 +17,13 @@ aioredis==2.0.1
 # Authentication & Security
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.6
-cryptography==41.0.8
+cryptography==41.0.7
 
 # AI & Voice Services
 openai==1.3.8
 elevenlabs==0.2.26
 pydub==0.25.1
-speech-recognition==3.10.0
+SpeechRecognition==3.14.3
 
 # HTTP Clients
 httpx==0.25.2
@@ -57,7 +56,7 @@ pydantic-settings==2.1.0
 # Utilities
 python-dotenv==1.0.0
 email-validator==2.1.0
-celery==5.3.4
+celery[redis]==5.3.4
 flower==2.0.1
 
 # Development
@@ -73,15 +72,14 @@ aiortc==1.6.0
 aioice==0.9.0
 
 # Background Tasks
-celery[redis]==5.3.4
 kombu==5.3.4
 
 # Caching
 python-memcached==1.59
 
 # Data Processing
-pandas==2.1.4
-numpy==1.25.2
+pandas==2.2.3
+numpy==1.26.4
 
 # Configuration
 pyyaml==6.0.1

--- a/requirements_troubleshooting_summary.md
+++ b/requirements_troubleshooting_summary.md
@@ -1,0 +1,94 @@
+# Requirements.txt Troubleshooting Session Summary
+
+## Overview
+This document summarizes a troubleshooting session for fixing issues with a Python requirements.txt file containing 88 dependencies for a FastAPI backend application.
+
+## Initial Problem
+The user encountered multiple issues when attempting to install packages from their requirements.txt file, including:
+- Non-existent packages
+- Invalid package versions
+- Missing system dependencies
+- Python version compatibility issues
+
+## Environment Setup Challenges
+
+### External Package Manager Conflict
+- **Issue**: Initial pip installation failed due to externally-managed Python environment
+- **Solution**: 
+  1. Installed `python3.13-venv` package via apt
+  2. Created virtual environment
+  3. Upgraded pip successfully
+
+## Major Issues Identified and Resolved
+
+### 1. PostgreSQL Dependencies
+- **Problem**: `psycopg2-binary==2.9.9` failed to build due to missing PostgreSQL development libraries
+- **Solution**: Installed system packages:
+  - `postgresql-server-dev-all`
+  - `libpq-dev`
+
+### 2. Invalid Package Versions
+- **Problem**: `cryptography==41.0.8` - version never released (versions skip from 41.0.7 to 42.0.0)
+- **Solution**: Changed to `cryptography==41.0.7`
+
+### 3. Incorrect Package Names
+- **Problem**: `speech-recognition==3.10.0` - package doesn't exist with this name/version
+- **Solution**: Corrected to `SpeechRecognition==3.14.3` (proper PyPI package name)
+
+### 4. Duplicate Dependencies
+- **Problems**: 
+  - `python-multipart==0.0.6` appeared twice
+  - `celery` appeared both standalone and with `[redis]` extra
+- **Solution**: 
+  - Removed duplicates
+  - Kept `celery[redis]==5.3.4`
+
+### 5. Python 3.13 Compatibility Issues
+- **Problem**: `pandas==2.1.4` compilation failed due to C API changes in Python 3.13
+  - Error: Cython-generated code had incorrect argument counts for `_PyLong_AsByteArray` function calls
+- **Solution**: 
+  - Updated `pandas` to `2.2.3` (Python 3.13 compatible)
+  - Updated `numpy` from `1.25.2` to `1.26.4` for compatibility
+
+## Outstanding Issues
+
+### 6. FFmpeg/Multimedia Libraries (Unresolved)
+- **Current Blocker**: `aiortc==1.6.0` dependency `av` package compilation failure
+- **Root Cause**: Missing FFmpeg development libraries (libavformat, libavcodec, etc.)
+- **Status**: Session ended while attempting to resolve this issue
+- **Next Steps**: Install FFmpeg development headers to enable `av` package compilation
+
+## Key Lessons Learned
+
+1. **System Dependencies**: Python packages with C extensions often require system development libraries
+2. **Version Compatibility**: Always verify package versions exist on PyPI before specifying them
+3. **Python Version Support**: Newer Python versions may require updated package versions
+4. **Package Naming**: Some packages have different names on PyPI than commonly expected
+5. **Duplicate Management**: Regular cleanup of requirements.txt prevents conflicts
+
+## Tools and Packages Involved
+
+### System Packages Installed
+- `python3.13-venv`
+- `postgresql-server-dev-all`
+- `libpq-dev`
+
+### Python Packages Fixed
+- `cryptography`: 41.0.8 → 41.0.7
+- `SpeechRecognition`: speech-recognition → SpeechRecognition==3.14.3
+- `pandas`: 2.1.4 → 2.2.3
+- `numpy`: 1.25.2 → 1.26.4
+- `celery`: Removed duplicate, kept celery[redis]==5.3.4
+
+## Current Status
+- ✅ Virtual environment successfully created
+- ✅ PostgreSQL dependencies resolved
+- ✅ Package version conflicts fixed
+- ✅ Python 3.13 compatibility issues resolved
+- ❌ **Blocked**: FFmpeg development libraries needed for `av` package compilation
+
+## Recommended Next Actions
+1. Install FFmpeg development libraries on the system
+2. Retry package installation
+3. Consider alternative packages if multimedia functionality isn't critical
+4. Document any additional system dependencies for future deployments


### PR DESCRIPTION
Update `backend/requirements.txt` to resolve dependency installation issues and Python 3.13 compatibility, and add a troubleshooting summary.

The `requirements.txt` file had several issues:
- Incorrect `cryptography` version (41.0.8 never released).
- Wrong package name for `SpeechRecognition`.
- Duplicate `celery` entries.
- `pandas` and `numpy` versions incompatible with Python 3.13.
- `psycopg2-binary` version causing build issues.
These changes address these specific problems to allow successful installation of dependencies. A `requirements_troubleshooting_summary.md` file has also been added to document the process and remaining issues.