### PR TITLE
Fix build errors for Next.js app

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   images: {
     domains: ['localhost'],
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,8 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.0.7",
+        "@tailwindcss/forms": "^0.5.7",
+        "@tailwindcss/typography": "^0.5.10",
         "@tanstack/react-query": "^5.17.0",
         "@tanstack/react-table": "^8.11.0",
         "autoprefixer": "^10.4.16",
@@ -43,8 +45,6 @@
         "zustand": "^4.4.7"
       },
       "devDependencies": {
-        "@tailwindcss/forms": "^0.5.7",
-        "@tailwindcss/typography": "^0.5.10",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.2",
         "@types/node": "^20.10.6",
@@ -2742,7 +2742,6 @@
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
       "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mini-svg-data-uri": "^1.2.3"
@@ -2755,7 +2754,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
       "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash.castarray": "^4.4.0",
@@ -9138,21 +9136,18 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -9305,7 +9300,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
       "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mini-svg-data-uri": "cli.js"
@@ -10118,7 +10112,6 @@
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
       "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,9 @@
     "postcss": "^8.4.32",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
-    "tailwind-merge": "^2.2.0"
+    "tailwind-merge": "^2.2.0",
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.10"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",
@@ -62,9 +64,7 @@
     "@testing-library/react": "^14.1.2",
     "@testing-library/jest-dom": "^6.2.0",
     "jest-environment-jsdom": "^29.7.0",
-    "prettier": "^3.1.1",
-    "@tailwindcss/forms": "^0.5.7",
-    "@tailwindcss/typography": "^0.5.10"
+    "prettier": "^3.1.1"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
Move Tailwind CSS plugins to dependencies and configure Next.js for standalone output to fix build errors.

The build was failing because `@tailwindcss/forms` and `@tailwindcss/typography` were listed in `devDependencies`, which are not installed during production builds (e.g., in Docker with `npm ci --omit=dev`). Moving them to `dependencies` ensures they are available. Additionally, `output: 'standalone'` is added to `next.config.js` to create an optimized build structure for Docker.