### PR TITLE
Fix module import errors in backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,7 @@ stripe==7.7.0
 # Monitoring & Logging
 sentry-sdk[fastapi]==1.32.0
 structlog==23.2.0
+loguru==0.7.2
 
 # Data Validation & Serialization
 pydantic==2.5.3


### PR DESCRIPTION
Add loguru to backend requirements to resolve ModuleNotFoundError.

The backend service failed to start due to a `ModuleNotFoundError: No module named 'loguru'`, as the `app/core/logging.py` module imports `loguru` but it was missing from `backend/requirements.txt`. This change adds the necessary dependency.