### PR TITLE
Enable SQLite fallback for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Database Configuration
-DATABASE_URL=postgresql://postgres:password@localhost:5432/voice_agent_db
+# Use SQLite by default for local development
+DATABASE_URL=sqlite+aiosqlite:///./test.db
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
 DATABASE_NAME=voice_agent_db

--- a/backend/app/core/types.py
+++ b/backend/app/core/types.py
@@ -1,0 +1,28 @@
+import uuid
+from sqlalchemy.types import TypeDecorator, CHAR
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+class GUID(TypeDecorator):
+    """Platform-independent GUID type.
+
+    Uses PostgreSQL's UUID type, otherwise stores as CHAR(36).
+    """
+
+    impl = CHAR
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == 'postgresql':
+            return dialect.type_descriptor(PG_UUID(as_uuid=True))
+        return dialect.type_descriptor(CHAR(36))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        if not isinstance(value, uuid.UUID):
+            value = uuid.UUID(str(value))
+        return str(value)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        return uuid.UUID(value)

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -10,11 +10,11 @@ from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey, Text, Integer, JSON, Numeric, Date
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
+from app.core.types import GUID
 
 
 class BillingStatus(enum.Enum):
@@ -53,8 +53,8 @@ class BillingRecord(Base):
     __tablename__ = "billing_records"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=False, index=True)
     
     # Billing identification
     invoice_number = Column(String(100), nullable=False, unique=True, index=True)
@@ -154,8 +154,8 @@ class UsageMetric(Base):
     __tablename__ = "usage_metrics"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=False, index=True)
     
     # Metric identification
     metric_type = Column(Enum(UsageType), nullable=False, index=True)
@@ -199,7 +199,7 @@ class UsageMetric(Base):
     # Billing status
     is_billable = Column(Boolean, default=True, nullable=False)
     is_billed = Column(Boolean, default=False, nullable=False)
-    billing_record_id = Column(UUID(as_uuid=True), ForeignKey("billing_records.id"), nullable=True)
+    billing_record_id = Column(GUID(), ForeignKey("billing_records.id"), nullable=True)
     
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/models/call.py
+++ b/backend/app/models/call.py
@@ -10,11 +10,11 @@ from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey, Text, Integer, JSON, Numeric, Float
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
+from app.core.types import GUID
 
 
 class CallStatus(enum.Enum):
@@ -61,9 +61,9 @@ class Call(Base):
     __tablename__ = "calls"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=False, index=True)
+    user_id = Column(GUID(), ForeignKey("users.id"), nullable=True, index=True)
     
     # Call identification
     call_sid = Column(String(255), nullable=True, unique=True, index=True)  # Twilio call SID
@@ -178,8 +178,8 @@ class CallTranscript(Base):
     __tablename__ = "call_transcripts"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    call_id = Column(UUID(as_uuid=True), ForeignKey("calls.id"), nullable=False, unique=True, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    call_id = Column(GUID(), ForeignKey("calls.id"), nullable=False, unique=True, index=True)
     
     # Transcript content
     full_transcript = Column(Text, nullable=True)
@@ -230,8 +230,8 @@ class CallAnalytics(Base):
     __tablename__ = "call_analytics"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    call_id = Column(UUID(as_uuid=True), ForeignKey("calls.id"), nullable=False, unique=True, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    call_id = Column(GUID(), ForeignKey("calls.id"), nullable=False, unique=True, index=True)
     
     # Sentiment analysis
     overall_sentiment = Column(Enum(SentimentType), nullable=True)

--- a/backend/app/models/knowledge_base.py
+++ b/backend/app/models/knowledge_base.py
@@ -9,11 +9,11 @@ from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey, Text, Integer, JSON
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
+from app.core.types import GUID
 
 
 class DocumentType(enum.Enum):
@@ -42,8 +42,8 @@ class KnowledgeBase(Base):
     __tablename__ = "knowledge_bases"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=False, index=True)
     
     # Basic information
     name = Column(String(255), nullable=False)
@@ -107,8 +107,8 @@ class KnowledgeDocument(Base):
     __tablename__ = "knowledge_documents"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    knowledge_base_id = Column(UUID(as_uuid=True), ForeignKey("knowledge_bases.id"), nullable=False, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    knowledge_base_id = Column(GUID(), ForeignKey("knowledge_bases.id"), nullable=False, index=True)
     
     # File information
     filename = Column(String(255), nullable=False)
@@ -148,7 +148,7 @@ class KnowledgeDocument(Base):
     last_accessed = Column(DateTime(timezone=True), nullable=True)
     
     # User information
-    uploaded_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    uploaded_by = Column(GUID(), ForeignKey("users.id"), nullable=True)
     
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/models/tenant.py
+++ b/backend/app/models/tenant.py
@@ -9,12 +9,23 @@ from decimal import Decimal
 from typing import Optional
 from uuid import uuid4
 
-from sqlalchemy import Column, String, Boolean, DateTime, Enum, Integer, Text, JSON, Numeric, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import (
+    Column,
+    String,
+    Boolean,
+    DateTime,
+    Enum,
+    Integer,
+    Text,
+    JSON,
+    Numeric,
+    ForeignKey,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
+from app.core.types import GUID
 
 
 class TenantStatus(enum.Enum):
@@ -39,7 +50,7 @@ class Tenant(Base):
     __tablename__ = "tenants"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
     name = Column(String(255), nullable=False, index=True)
     subdomain = Column(String(100), unique=True, nullable=True, index=True)
     domain = Column(String(255), nullable=True)
@@ -159,8 +170,8 @@ class TenantSubscription(Base):
     __tablename__ = "tenant_subscriptions"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, unique=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=False, unique=True)
     
     # Subscription details
     plan = Column(Enum(SubscriptionPlan), default=SubscriptionPlan.FREE, nullable=False)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -9,7 +9,7 @@ from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey, Text
-from sqlalchemy.dialects.postgresql import UUID
+from app.core.types import GUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -30,7 +30,7 @@ class User(Base):
     __tablename__ = "users"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
     email = Column(String(255), unique=True, index=True, nullable=False)
     username = Column(String(100), unique=True, index=True, nullable=True)
     
@@ -49,7 +49,7 @@ class User(Base):
     role = Column(Enum(UserRole), default=UserRole.TENANT_USER, nullable=False)
     
     # Multi-tenant relationship
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=True)
     
     # Security and session management
     last_login = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/webhook.py
+++ b/backend/app/models/webhook.py
@@ -9,11 +9,11 @@ from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import Column, String, Boolean, DateTime, Enum, ForeignKey, Text, Integer, JSON
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
+from app.core.types import GUID
 
 
 class WebhookEventType(enum.Enum):
@@ -54,9 +54,9 @@ class Webhook(Base):
     __tablename__ = "webhooks"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    tenant_id = Column(GUID(), ForeignKey("tenants.id"), nullable=False, index=True)
+    user_id = Column(GUID(), ForeignKey("users.id"), nullable=False, index=True)
     
     # Webhook details
     name = Column(String(255), nullable=False)
@@ -138,8 +138,8 @@ class WebhookEvent(Base):
     __tablename__ = "webhook_events"
     
     # Primary identification
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    webhook_id = Column(UUID(as_uuid=True), ForeignKey("webhooks.id"), nullable=False, index=True)
+    id = Column(GUID(), primary_key=True, default=uuid4, index=True)
+    webhook_id = Column(GUID(), ForeignKey("webhooks.id"), nullable=False, index=True)
     
     # Event identification
     event_id = Column(String(255), nullable=False, unique=True, index=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
 from app.core.config import settings
 from app.core.database import engine, Base
+from sqlalchemy import text
 from app.core.database_init import create_tables, create_sample_data
 from app.core.redis_client import redis_client
 from app.api.v1.router import api_router
@@ -142,7 +143,7 @@ async def health_check():
     try:
         # Check database connection
         async with engine.begin() as conn:
-            await conn.execute("SELECT 1")
+            await conn.execute(text("SELECT 1"))
         
         # Check Redis connection
         await redis_client.ping()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ sqlalchemy==2.0.23
 alembic==1.12.1
 asyncpg==0.29.0
 psycopg2-binary==2.9.9
+aiosqlite==0.21.0
 
 # Redis
 redis==4.6.0


### PR DESCRIPTION
## Summary
- allow using SQLite for dev environment
- add custom GUID type for cross-database UUIDs
- update requirements and env defaults
- fix health check query

## Testing
- `python3 test_startup.py`

------
https://chatgpt.com/codex/tasks/task_e_686de02c691c832287a5affade839d98