### PR TITLE
Fix healthcheck and sample data duplication

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     portaudio19-dev \
     python3-pyaudio \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -39,5 +40,4 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Run the applicationCMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/app/core/database_init.py
+++ b/backend/app/core/database_init.py
@@ -5,6 +5,7 @@ Creates tables and populates with sample data for development
 
 import asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -37,8 +38,10 @@ async def create_sample_data():
     
     async with async_session_maker() as session:
         try:
-            # Check if demo tenant already exists
-            existing_tenant = await session.get(Tenant, "b1244b00-5bb5-4f55-94e3-720d683ae82c")
+            # Check if demo tenant already exists by subdomain
+            existing_tenant = await session.scalar(
+                select(Tenant).where(Tenant.subdomain == "demo")
+            )
             if existing_tenant:
                 print("ℹ️  Sample data creation skipped: Demo tenant already exists")
                 return


### PR DESCRIPTION
## Summary
- install curl in backend Dockerfile so container healthcheck works
- check demo tenant by subdomain before inserting sample data to avoid duplicate key errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686e0c50f8e88322987a2a45874dd162