### PR TITLE
Fix backend container exit

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,4 +40,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Run the applicationCMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Run the application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -186,7 +186,9 @@ async def global_exception_handler(request, exc):
 
 if __name__ == "__main__":
     import uvicorn
-    
+
+    print("🚀 Starting Uvicorn server...")
+
     uvicorn.run(
         "main:app",
         host="0.0.0.0",


### PR DESCRIPTION
## Summary
- ensure backend Dockerfile starts uvicorn
- add startup debug log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68762beddb548322a542165fcfe1f356