### PR TITLE
Implement basic authentication hooks and add analytics API

### DIFF
--- a/backend/app/api/v1/endpoints/analytics.py
+++ b/backend/app/api/v1/endpoints/analytics.py
@@ -1,12 +1,50 @@
 """
-Analytics API Endpoints - Basic Implementation
+Analytics API Endpoints
+Provides basic analytics and usage metrics
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func
+
+from app.core.database import get_db
+from app.services.auth import auth_service, security
+from app.models.billing import UsageMetric
+from app.schemas.analytics import UsageMetricListResponse, UsageMetricResponse
 
 router = APIRouter()
 
-@router.get("/")
-async def get_analytics():
-    """Get analytics - placeholder implementation"""
-    return {"message": "Analytics endpoint - coming soon"}
+
+@router.get("/usage", response_model=UsageMetricListResponse)
+async def list_usage_metrics(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: AsyncSession = Depends(get_db),
+):
+    """List usage metrics for the current tenant"""
+    user = await auth_service.get_current_user(db, credentials)
+    if not user.tenant_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User is not associated with a tenant")
+
+    query = select(UsageMetric).where(UsageMetric.tenant_id == user.tenant_id).order_by(UsageMetric.date.desc())
+    count_query = select(func.count()).select_from(UsageMetric).where(UsageMetric.tenant_id == user.tenant_id)
+
+    result = await db.execute(query.offset(skip).limit(limit))
+    metrics = result.scalars().all()
+    total = (await db.execute(count_query)).scalar()
+
+    metric_responses = [
+        UsageMetricResponse(
+            id=str(m.id),
+            metric_type=m.metric_type.value,
+            metric_name=m.metric_name,
+            date=m.date,
+            count=m.count,
+            cost_usd=float(m.cost_usd) if m.cost_usd is not None else None,
+        )
+        for m in metrics
+    ]
+
+    return UsageMetricListResponse(metrics=metric_responses, total=total, skip=skip, limit=limit)

--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -1,12 +1,43 @@
 """
-Billing API Endpoints - Basic Implementation
+Billing API Endpoints
+Provide subscription information for tenants
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.core.database import get_db
+from app.services.auth import auth_service, security
+from app.models.tenant import TenantSubscription
+from app.schemas.billing import SubscriptionResponse
 
 router = APIRouter()
 
-@router.get("/")
-async def list_billing():
-    """List billing - placeholder implementation"""
-    return {"message": "Billing endpoint - coming soon"}
+
+@router.get("/subscription", response_model=SubscriptionResponse)
+async def get_subscription(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get the current tenant subscription"""
+    user = await auth_service.get_current_user(db, credentials)
+    if not user.tenant_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User is not associated with a tenant")
+
+    stmt = select(TenantSubscription).where(TenantSubscription.tenant_id == user.tenant_id)
+    result = await db.execute(stmt)
+    sub = result.scalar_one_or_none()
+    if not sub:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subscription not found")
+
+    return SubscriptionResponse(
+        tenant_id=str(sub.tenant_id),
+        plan=sub.plan.value,
+        status=sub.status,
+        monthly_price=float(sub.monthly_price),
+        price_per_call=float(sub.price_per_call),
+        current_period_start=sub.current_period_start,
+        current_period_end=sub.current_period_end,
+    )

--- a/backend/app/core/database_init.py
+++ b/backend/app/core/database_init.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from app.core.database import async_session_maker, Base, engine
 from app.models.user import User, UserRole
 from app.models.tenant import Tenant, TenantStatus, TenantSubscription, SubscriptionPlan
+from app.models.billing import UsageMetric, UsageType
 try:
     from app.services.auth import auth_service
 except ImportError:
@@ -120,6 +121,19 @@ async def create_sample_data():
                 is_verified=True
             )
             session.add(regular_user)
+
+            # Sample usage metric
+            metric = UsageMetric(
+                tenant_id=tenant.id,
+                metric_type=UsageType.CALLS,
+                metric_name="demo_calls",
+                date=datetime.now(timezone.utc).date(),
+                count=5,
+                unit_price_usd=0.10,
+                billing_unit="call",
+                cost_usd=0.50,
+            )
+            session.add(metric)
             
             await session.commit()
             

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,0 +1,20 @@
+from datetime import date
+from typing import List, Optional
+from pydantic import BaseModel
+
+class UsageMetricResponse(BaseModel):
+    id: str
+    metric_type: str
+    metric_name: str
+    date: date
+    count: int
+    cost_usd: Optional[float] = None
+
+    class Config:
+        from_attributes = True
+
+class UsageMetricListResponse(BaseModel):
+    metrics: List[UsageMetricResponse]
+    total: int
+    skip: int
+    limit: int

--- a/backend/app/schemas/billing.py
+++ b/backend/app/schemas/billing.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+class SubscriptionResponse(BaseModel):
+    tenant_id: str
+    plan: str
+    status: str
+    monthly_price: float
+    price_per_call: float
+    current_period_start: Optional[datetime] = None
+    current_period_end: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      <p>Administration tools coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -1,0 +1,8 @@
+export default function DocsPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Documentation</h1>
+      <p>Platform documentation will be available here soon.</p>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import React from 'react'
 import { AuthProvider } from '@/hooks/useAuth'
+import NavBar from '@/components/NavBar'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -21,6 +22,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <AuthProvider>
           <div className="min-h-screen bg-background font-sans antialiased">
+            <NavBar />
             {children}
           </div>
         </AuthProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,29 +4,6 @@ import Link from 'next/link'
 export default function HomePage() {
   return (
     <div className="flex flex-col min-h-screen">
-      {/* Header */}
-      <header className="px-4 lg:px-6 h-14 flex items-center border-b">
-        <Link className="flex items-center justify-center" href="/">
-          <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
-            <span className="text-primary-foreground font-bold text-sm">VA</span>
-          </div>
-          <span className="ml-2 text-lg font-semibold">Voice Agent Platform</span>
-        </Link>
-        <nav className="ml-auto flex gap-4 sm:gap-6">
-          <Link className="text-sm font-medium hover:underline underline-offset-4" href="/dashboard">
-            Dashboard
-          </Link>
-          <Link className="text-sm font-medium hover:underline underline-offset-4" href="/docs">
-            Documentation
-          </Link>
-          <Link className="text-sm font-medium hover:underline underline-offset-4" href="/login">
-            Login
-          </Link>
-          <Link className="text-sm font-medium hover:underline underline-offset-4" href="/register">
-            Register
-          </Link>
-        </nav>
-      </header>
 
       {/* Main Content */}
       <main className="flex-1">

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,0 +1,25 @@
+"use client";
+import Link from 'next/link';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function NavBar() {
+  const { user, logout } = useAuth();
+  return (
+    <header className="px-4 lg:px-6 h-14 flex items-center border-b bg-white">
+      <Link className="flex items-center justify-center" href="/">
+        <div className="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center text-white font-bold text-sm">VA</div>
+        <span className="ml-2 text-lg font-semibold">Voice Agent</span>
+      </Link>
+      <nav className="ml-auto flex gap-4 sm:gap-6">
+        <Link className="text-sm font-medium hover:underline" href="/dashboard">Dashboard</Link>
+        <Link className="text-sm font-medium hover:underline" href="/admin">Admin</Link>
+        <Link className="text-sm font-medium hover:underline" href="/docs">Docs</Link>
+        {user ? (
+          <button className="text-sm font-medium" onClick={logout}>Logout</button>
+        ) : (
+          <Link className="text-sm font-medium hover:underline" href="/login">Login</Link>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,17 @@
 import axios from 'axios';
 
+let isRefreshing = false;
+let refreshSubscribers: Array<(token: string) => void> = [];
+
+const subscribeTokenRefresh = (cb: (token: string) => void) => {
+  refreshSubscribers.push(cb);
+};
+
+const onRefreshed = (token: string) => {
+  refreshSubscribers.forEach((cb) => cb(token));
+  refreshSubscribers = [];
+};
+
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
 });
@@ -11,5 +23,48 @@ api.interceptors.request.use((config) => {
   }
   return config;
 });
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      const refreshToken = typeof window !== 'undefined' ? localStorage.getItem('refreshToken') : null;
+      if (refreshToken) {
+        if (isRefreshing) {
+          return new Promise((resolve) => {
+            subscribeTokenRefresh((token) => {
+              originalRequest.headers.Authorization = `Bearer ${token}`;
+              resolve(api(originalRequest));
+            });
+          });
+        }
+
+        originalRequest._retry = true;
+        isRefreshing = true;
+        try {
+          const resp = await axios.post(
+            '/api/v1/auth/refresh',
+            { refresh_token: refreshToken },
+            { baseURL: api.defaults.baseURL }
+          );
+          const newToken = resp.data.access_token;
+          const newRefresh = resp.data.refresh_token;
+          localStorage.setItem('accessToken', newToken);
+          localStorage.setItem('refreshToken', newRefresh);
+          api.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
+          onRefreshed(newToken);
+          return api(originalRequest);
+        } catch (err) {
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+        } finally {
+          isRefreshing = false;
+        }
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default api;


### PR DESCRIPTION
## Summary
- implement usage metrics endpoint and subscription endpoint
- include sample usage data during DB init
- store tokens on login and handle refresh in API service
- add navigation bar with links to admin and docs pages
- create placeholder admin and docs pages

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779aca9ef8832294f0093461d8a4bb