### PR TITLE
Fix name error in security module

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, status, Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.models.user import User, UserRole
+from app.api.deps import get_db
 
 
 class Permission:
@@ -214,7 +215,6 @@ def require_super_admin_dependency():
         db = Depends(get_db)
     ) -> User:
         from app.services.auth import auth_service
-        from app.api.deps import get_db
         user = await auth_service.get_current_user(db, credentials)
         
         if user.role != UserRole.SUPER_ADMIN:
@@ -235,7 +235,6 @@ def require_admin_dependency():
         db = Depends(get_db)
     ) -> User:
         from app.services.auth import auth_service
-        from app.api.deps import get_db
         user = await auth_service.get_current_user(db, credentials)
         
         if user.role not in [UserRole.SUPER_ADMIN, UserRole.TENANT_ADMIN]:
@@ -256,7 +255,6 @@ def require_tenant_admin_dependency():
         db = Depends(get_db)
     ) -> User:
         from app.services.auth import auth_service
-        from app.api.deps import get_db
         user = await auth_service.get_current_user(db, credentials)
         
         if user.role == UserRole.SUPER_ADMIN:
@@ -280,7 +278,6 @@ def require_verified_user_dependency():
         db = Depends(get_db)
     ) -> User:
         from app.services.auth import auth_service
-        from app.api.deps import get_db
         user = await auth_service.get_current_user(db, credentials)
         
         if not user.is_verified:


### PR DESCRIPTION
Move `get_db` import to module level to resolve `NameError` during application startup.

The `NameError: name 'get_db' is not defined` occurred because `Depends(get_db)` was being evaluated at module load time in `app/core/security.py`, but `get_db` was only imported *inside* the functions where it was used. This PR moves the `get_db` import to the top of the module and removes the redundant imports within the functions, ensuring `get_db` is available when `Depends` is evaluated.