### PR TITLE
Fix frontend health check

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 # Frontend Dockerfile for Voice Agent Platform
 FROM node:18-alpine AS base
 
+# Install runtime dependencies needed by the health check
+RUN apk add --no-cache curl
+
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.


### PR DESCRIPTION
## Summary
- ensure frontend Docker image includes `curl` so the healthcheck works

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e53c4bbac832284c44a81c133e6ae