### PR TITLE
Fix UUID processing for asyncpg

### DIFF
--- a/backend/app/core/types.py
+++ b/backend/app/core/types.py
@@ -25,4 +25,6 @@ class GUID(TypeDecorator):
     def process_result_value(self, value, dialect):
         if value is None:
             return value
-        return uuid.UUID(value)
+        # asyncpg may return its own UUID type which doesn't behave like a
+        # string. Cast to ``str`` first so ``uuid.UUID`` can handle it.
+        return uuid.UUID(str(value))


### PR DESCRIPTION
## Summary
- handle asyncpg UUID objects on result processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e58f67ba483228df19262830bacd3