### PR TITLE
Implement logout-all and consistent token validation

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,69 @@
+# Environment Configuration
+ENVIRONMENT=development
+DEBUG=true
+LOG_LEVEL=INFO
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Security
+SECRET_KEY=your-secret-key-change-in-production
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# Database Configuration
+# Use SQLite by default for local development
+DATABASE_URL=sqlite+aiosqlite:///./test.db
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_NAME=voice_agent_db
+DATABASE_USER=postgres
+DATABASE_PASSWORD=password
+
+# Redis Configuration
+REDIS_URL=redis://localhost:6379/0
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# AI Service API Keys
+OPENAI_API_KEY=your-openai-api-key-here
+ELEVENLABS_API_KEY=your-elevenlabs-api-key-here
+
+# AWS Configuration
+AWS_ACCESS_KEY_ID=your-aws-access-key
+AWS_SECRET_ACCESS_KEY=your-aws-secret-key
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=your-s3-bucket
+AWS_S3_BUCKET_AUDIO=your-s3-audio-bucket
+
+# Voice Configuration
+ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+ELEVENLABS_STABILITY=0.5
+ELEVENLABS_SIMILARITY_BOOST=0.75
+
+# OpenAI Configuration
+OPENAI_MODEL=gpt-4
+OPENAI_MAX_TOKENS=1500
+OPENAI_TEMPERATURE=0.7
+
+# Telephony (Optional)
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
+
+# Webhook Configuration
+WEBHOOK_SECRET=development-webhook-secret
+
+# Payment Processing (Optional)
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Monitoring (Optional - leave empty if not using Sentry)
+SENTRY_DSN=
+
+# CORS Configuration
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+ALLOWED_HOSTS=*
+
+# File Upload Configuration
+MAX_FILE_SIZE_MB=50
+ALLOWED_FILE_TYPES=pdf,txt,docx,md

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -393,12 +393,9 @@ async def logout_all_sessions(
     # 2. Blacklist them all
     # 3. Optionally, increment a user session version to invalidate all tokens
     
-    # Implement basic session management by invalidating user tokens
-    # In a production system, you would maintain a token blacklist in Redis
+    # Implement basic session management by setting a logout-all flag in Redis
     try:
-        # For now, we'll invalidate by checking token validity and returning success
-        # In a full implementation, add tokens to a blacklist in Redis
-        pass
+        await auth_service.logout_all_sessions(str(current_user.id))
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary
- add redis-based logout-all flag support
- reject tokens if logout-all flag is set
- implement /logout-all endpoint using new auth service method
- ensure JWT verification is centralized in dependencies
- add example `.env` with all required variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c722ae308322baedae441798c16f