### PR TITLE
fix: enforce token type validation

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -42,7 +42,10 @@ async def get_current_user(
     )
     
     try:
-        token_data = await auth_service.verify_token(credentials.credentials)
+        token_data = await auth_service.verify_token(
+            credentials.credentials,
+            token_type="access",
+        )
         if not token_data:
             raise credentials_exception
         user_id = token_data.user_id
@@ -178,7 +181,10 @@ async def get_optional_user(
     token = authorization.split("Bearer ")[1]
     
     try:
-        token_data = await auth_service.verify_token(token)
+        token_data = await auth_service.verify_token(
+            token,
+            token_type="access",
+        )
         if not token_data:
             return None
         user_id = token_data.user_id

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -249,7 +249,10 @@ async def refresh_token(
     """
     try:
         # Verify refresh token
-        token_data = await auth_service.verify_token(refresh_request.refresh_token)
+        token_data = await auth_service.verify_token(
+            refresh_request.refresh_token,
+            token_type="refresh",
+        )
         if not token_data:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
## Summary
- ensure JWT verification checks expected token type
- update dependencies and refresh endpoint to require access vs refresh tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3ac4c664832280eee5a1e3f06d6c