### PR TITLE
Fix unescaped apostrophes in frontend pages

### DIFF
--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -45,8 +45,8 @@ export default function ForgotPasswordPage() {
         <div className="text-center p-6 bg-white shadow-md rounded-lg w-full max-w-sm">
           <div className="text-green-500 text-xl mb-4">✓</div>
           <h2 className="text-xl font-bold mb-2">Check Your Email</h2>
-          <p className="mb-4">We've sent password reset instructions to your email address.</p>
-          <p className="text-sm text-gray-500 mb-4">If you don't receive an email within a few minutes, check your spam folder.</p>
+          <p className="mb-4">We&apos;ve sent password reset instructions to your email address.</p>
+          <p className="text-sm text-gray-500 mb-4">If you don&apos;t receive an email within a few minutes, check your spam folder.</p>
           <Link href="/login" className="text-indigo-600 hover:underline">
             Return to login
           </Link>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -153,7 +153,7 @@ export default function LoginPage() {
             </div>
             
             <div className="text-center">
-              <span className="text-sm text-gray-600">Don't have an account? </span>
+              <span className="text-sm text-gray-600">Don&apos;t have an account? </span>
               <Link 
                 href="/register" 
                 className="text-sm text-indigo-600 hover:text-indigo-500 hover:underline transition-colors duration-200"
@@ -163,7 +163,7 @@ export default function LoginPage() {
             </div>
             
             <div className="text-center">
-              <span className="text-sm text-gray-600">Didn't receive verification email? </span>
+              <span className="text-sm text-gray-600">Didn&apos;t receive verification email? </span>
               <Link 
                 href="/resend-verification" 
                 className="text-sm text-indigo-600 hover:text-indigo-500 hover:underline transition-colors duration-200"

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -195,7 +195,7 @@ export default function RegisterPage() {
             </div>
             
             <div className="text-center">
-              <span className="text-sm text-gray-600">Didn't receive verification email? </span>
+              <span className="text-sm text-gray-600">Didn&apos;t receive verification email? </span>
               <Link 
                 href="/resend-verification" 
                 className="text-sm text-indigo-600 hover:text-indigo-500 hover:underline transition-colors duration-200"
@@ -213,8 +213,8 @@ export default function RegisterPage() {
                 </div>
                 <div className="ml-3">
                   <p className="text-sm text-blue-700">
-                    <strong>Note:</strong> After registering, you'll need to verify your email address. 
-                    If you don't receive the verification email, you can request a new one.
+                    <strong>Note:</strong> After registering, you&apos;ll need to verify your email address. 
+                    If you don&apos;t receive the verification email, you can request a new one.
                   </p>
                 </div>
               </div>

--- a/frontend/src/app/resend-verification/page.tsx
+++ b/frontend/src/app/resend-verification/page.tsx
@@ -46,9 +46,9 @@ export default function ResendVerificationPage() {
           <div className="text-center">
             <div className="text-green-500 text-5xl mb-4">✓</div>
             <h2 className="text-xl font-bold mb-2">Email Sent!</h2>
-            <p className="mb-4">We've sent a verification link to your email address.</p>
+            <p className="mb-4">We&apos;ve sent a verification link to your email address.</p>
             <p className="text-sm text-gray-500 mb-4">
-              If you don't receive an email within a few minutes, check your spam folder or try again.
+              If you don&apos;t receive an email within a few minutes, check your spam folder or try again.
             </p>
             <div className="mt-6 flex justify-center space-x-4">
               <Link href="/login" className="text-indigo-600 hover:underline">
@@ -59,7 +59,7 @@ export default function ResendVerificationPage() {
         ) : (
           <>
             <p className="mb-4 text-gray-600">
-              Enter your email address below and we'll send you a new verification link.
+              Enter your email address below and we&apos;ll send you a new verification link.
             </p>
             
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -68,7 +68,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const getErrorMessage = (error: AxiosError): string => {
+  const getErrorMessage = (error: AxiosError<{detail?: string}>): string => {
     if (error.response?.data?.detail) {
       return error.response.data.detail;
     }


### PR DESCRIPTION
Fix ESLint `react/no-unescaped-entities` errors and a TypeScript error to enable successful frontend build.

---
<a href="https://cursor.com/background-agent?bcId=bc-a60ffadf-15b1-4dee-9709-edd3b62c6994">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a60ffadf-15b1-4dee-9709-edd3b62c6994">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>