### PR TITLE
feat: support profile updates in auth context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ marimo/_lsp/
 __marimo__/
 frontend/node_modules/
 frontend/.next/
+!frontend/src/lib/
+!frontend/src/lib/**

--- a/frontend/src/app/api/profile/route.ts
+++ b/frontend/src/app/api/profile/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// TODO: replace with real auth/session lookup
+async function getCurrentUserId(req: NextRequest): Promise<string | null> {
+  // If you use cookies/JWT, parse here. Return null if unauthenticated.
+  return 'demo-user-id';
+}
+
+export async function PUT(req: NextRequest) {
+  const userId = await getCurrentUserId(req);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim() : undefined;
+  const phone = typeof body.phone === 'string' ? body.phone.trim() : undefined;
+  const avatarUrl = typeof body.avatarUrl === 'string' ? body.avatarUrl.trim() : undefined;
+
+  // Basic validation
+  if (name && name.length > 100) return NextResponse.json({ error: 'Name too long' }, { status: 400 });
+  if (phone && phone.length > 30) return NextResponse.json({ error: 'Phone too long' }, { status: 400 });
+
+  // TODO: persist to your real backend. For now, echo back.
+  const updated = {
+    id: userId,
+    name: name ?? 'Demo User',
+    email: 'demo@example.com',
+    phone,
+    avatarUrl,
+  };
+
+  return NextResponse.json(updated, { status: 200 });
+}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -9,9 +9,9 @@ import { LoadingSpinner } from '@/components/LoadingSpinner';
 import Link from 'next/link';
 
 const schema = z.object({
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  username: z.string().min(2).optional(),
+  name: z.string().max(100).optional(),
+  phone: z.string().max(30).optional(),
+  avatarUrl: z.string().url().optional(),
 });
 
 type FormData = z.infer<typeof schema>;
@@ -26,41 +26,54 @@ export default function ProfilePage() {
     formState: { errors, isSubmitting },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
-    defaultValues: { first_name: user?.first_name ?? '', last_name: user?.last_name ?? '', username: user?.username ?? '' },
+    defaultValues: { name: user?.name ?? '', phone: user?.phone ?? '', avatarUrl: user?.avatarUrl ?? '' },
   });
 
   const onSubmit = async (data: FormData) => {
-    try {
-      setUpdateSuccess(false);
-      await updateProfile(data);
-      showToast('Profile updated successfully!', 'success');
-      setUpdateSuccess(true);
-    } catch (error) {
-      console.error('Profile update error:', error);
-      showToast('Failed to update profile. Please try again.', 'error');
+    setUpdateSuccess(false);
+    const result = await updateProfile(data);
+    if (!result.ok) {
+      showToast(result.error ?? 'Failed to update profile', 'error');
+      return;
     }
+    showToast('Profile updated successfully!', 'success');
+    setUpdateSuccess(true);
   };
 
-
+  if (loading) {
+    return (
+      <div className="p-4 max-w-md mx-auto">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 max-w-md mx-auto">
       <h1 className="text-2xl font-bold mb-4">My Profile</h1>
-      
+
       {user && !user.is_verified && (
         <div className="mb-6 bg-yellow-50 border-l-4 border-yellow-400 p-4">
           <div className="flex">
             <div className="flex-shrink-0">
               <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                <path
+                  fillRule="evenodd"
+                  d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                  clipRule="evenodd"
+                />
               </svg>
             </div>
             <div className="ml-3">
               <p className="text-sm text-yellow-700">
-                Your email address is not verified. Some features may be limited. Please check your inbox for a verification email or 
-                <Link href="/resend-verification" className="font-medium underline text-yellow-700 hover:text-yellow-600 ml-1">
+                Your email address is not verified. Some features may be limited. Please check your inbox for a verification email or
+                <Link
+                  href="/resend-verification"
+                  className="font-medium underline text-yellow-700 hover:text-yellow-600 ml-1"
+                >
                   request a new verification link
-                </Link>.
+                </Link>
+                .
               </p>
             </div>
           </div>
@@ -68,26 +81,32 @@ export default function ProfilePage() {
       )}
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium" htmlFor="first_name">First Name</label>
-          <input id="first_name" {...register('first_name')} className="w-full border rounded px-3 py-2 text-sm" />
-          {errors.first_name && <p className="text-red-500 text-sm">{errors.first_name.message}</p>}
+          <label className="block text-sm font-medium" htmlFor="name">
+            Name
+          </label>
+          <input id="name" {...register('name')} className="w-full border rounded px-3 py-2 text-sm" />
+          {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
         </div>
         <div>
-          <label className="block text-sm font-medium" htmlFor="last_name">Last Name</label>
-          <input id="last_name" {...register('last_name')} className="w-full border rounded px-3 py-2 text-sm" />
-          {errors.last_name && <p className="text-red-500 text-sm">{errors.last_name.message}</p>}
+          <label className="block text-sm font-medium" htmlFor="phone">
+            Phone
+          </label>
+          <input id="phone" {...register('phone')} className="w-full border rounded px-3 py-2 text-sm" />
+          {errors.phone && <p className="text-red-500 text-sm">{errors.phone.message}</p>}
         </div>
         <div>
-          <label className="block text-sm font-medium" htmlFor="username">Username</label>
-          <input id="username" {...register('username')} className="w-full border rounded px-3 py-2 text-sm" />
-          {errors.username && <p className="text-red-500 text-sm">{errors.username.message}</p>}
+          <label className="block text-sm font-medium" htmlFor="avatarUrl">
+            Avatar URL
+          </label>
+          <input id="avatarUrl" {...register('avatarUrl')} className="w-full border rounded px-3 py-2 text-sm" />
+          {errors.avatarUrl && <p className="text-red-500 text-sm">{errors.avatarUrl.message}</p>}
         </div>
-        <button 
-          type="submit" 
-          disabled={isSubmitting || loading} 
+        <button
+          type="submit"
+          disabled={isSubmitting}
           className="bg-indigo-600 text-white px-4 py-2 rounded flex items-center justify-center"
         >
-          {isSubmitting || loading ? (
+          {isSubmitting ? (
             <>
               <LoadingSpinner size="sm" />
               <span className="ml-2">Saving...</span>
@@ -96,9 +115,7 @@ export default function ProfilePage() {
             'Save'
           )}
         </button>
-        {updateSuccess && (
-          <p className="text-green-500 mt-2">Profile updated successfully!</p>
-        )}
+        {updateSuccess && <p className="text-green-500 mt-2">Profile updated successfully!</p>}
       </form>
     </div>
   );

--- a/frontend/src/hooks/use-dashboard-data.ts
+++ b/frontend/src/hooks/use-dashboard-data.ts
@@ -102,9 +102,9 @@ export const useDashboardData = (): UseDashboardDataReturn => {
         ...healthData,
         status: healthData.status as SystemStatusType,
         services: {
+          ...healthData.services,
           database: healthData.services?.database || 'unknown',
-          redis: healthData.services?.redis || 'unknown',
-          ...healthData.services
+          redis: healthData.services?.redis || 'unknown'
         }
       });
     }

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -1,0 +1,8 @@
+export const apiClient = {
+  async getDemoCalls() {
+    return { calls: [], total: 0 };
+  },
+  async getSystemStatus() {
+    return { status: 'healthy', services: { database: 'connected', redis: 'connected' } };
+  },
+};

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,15 @@
+export type CallStatus = 'active' | 'completed' | 'failed';
+export type SystemStatusType = 'healthy' | 'degraded' | 'unhealthy';
+
+export const TIMING = {
+  REFRESH_INTERVAL_MS: 30000,
+};
+
+export const DEFAULTS = {
+  STATS: {
+    totalCalls: 0,
+    activeCalls: 0,
+    averageDuration: 0,
+    successRate: 0,
+  },
+};

--- a/frontend/src/lib/error-handling.ts
+++ b/frontend/src/lib/error-handling.ts
@@ -1,0 +1,19 @@
+export async function safeAsync<T>(fn: () => Promise<T>, fallback: T): Promise<{ data: T; error: unknown }>{
+  try {
+    const data = await fn();
+    return { data, error: null };
+  } catch (err) {
+    logError(err);
+    return { data: fallback, error: err };
+  }
+}
+
+export function logError(error: unknown, context?: Record<string, unknown>) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(context, error);
+  }
+}
+
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary
- add typed updateProfile to auth context
- wire profile page to call updateProfile and handle loading states
- implement /api/profile route and stub libs for build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ae5959a48322a32a84985903c0a6